### PR TITLE
turing: remove incorrect divided by 20 on the delay

### DIFF
--- a/slamfan/twitch/cogs/turing.py
+++ b/slamfan/twitch/cogs/turing.py
@@ -177,7 +177,7 @@ class Turing(CogBase):
 
                 rnd_delay = randint(self.__msg_delay[0], self.__msg_delay[1])
 
-                while delay < (rnd_delay // 20):
+                while delay < rnd_delay:
 
                     if self._die.is_set():
                         return


### PR DESCRIPTION
When testing, I forgot to remove the shortened delay for the turing emissions.